### PR TITLE
Update package.json - allow Node 18 to be used

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/orvad/strapi-provider-email-postmark/issues"
   },
   "engines": {
-    "node": ">=14.19.1 <=16.x.x",
+    "node": ">=14.19.1 <=18.x.x",
     "npm": ">=6.0.0"
   },
   "license": "MIT"


### PR DESCRIPTION
Node 18 is now recommended by Strapi Docs: https://docs.strapi.io/dev-docs/installation/cli